### PR TITLE
Fix for GetValue<Float> when value is 0

### DIFF
--- a/Conf/Providers/YamlProvider.cs
+++ b/Conf/Providers/YamlProvider.cs
@@ -136,6 +136,16 @@ namespace LibConf.Providers
                 {
                     return (T)value;
                 }
+                else if (typeof(T) == typeof(float?) && type == typeof(int))
+                {
+                    object retVal = null;
+                    try
+                    {
+                        retVal = Convert.ToSingle(value);
+                    }
+                    catch { }
+                    return (T)retVal;
+                }
             }
             catch (KeyNotFoundException) { }
 


### PR DESCRIPTION
Fix for when a float setting in the file has a value of 0, GetFloat returns null. Not sure if this is a good way to do it, but it works.